### PR TITLE
Compatability restructuring

### DIFF
--- a/RNDeviceInfo.xcodeproj/project.pbxproj
+++ b/RNDeviceInfo.xcodeproj/project.pbxproj
@@ -219,6 +219,8 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(BUILT_PRODUCTS_DIR)/usr/local/include",
+					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/../react-native/React/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "-ObjC";
@@ -233,6 +235,8 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(BUILT_PRODUCTS_DIR)/usr/local/include",
+					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/../react-native/React/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "-ObjC";

--- a/RNDeviceInfo/RNDeviceInfo.h
+++ b/RNDeviceInfo/RNDeviceInfo.h
@@ -9,7 +9,7 @@
 #import <UIKit/UIKit.h>
 #import <sys/utsname.h>
 
-#import <React/RCTBridgeModule.h>
+#import "RCTBridgeModule.h"
 
 @interface RNDeviceInfo : NSObject <RCTBridgeModule>
 

--- a/RNDeviceInfo/RNDeviceInfo.m
+++ b/RNDeviceInfo/RNDeviceInfo.m
@@ -13,6 +13,8 @@
 
 @end
 
+static NSString *KEY_DEVICE_INFO = @"DeviceInfo";
+
 @implementation RNDeviceInfo
 {
 
@@ -176,7 +178,7 @@ RCT_EXPORT_MODULE()
 
 RCT_REMAP_METHOD(getDeviceInfo, resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-    resolve([self constantsToExport][@"DeviceInfo"]);
+    resolve([self constantsToExport][KEY_DEVICE_INFO]);
 }
 
 - (NSDictionary *)constantsToExport
@@ -186,7 +188,7 @@ RCT_REMAP_METHOD(getDeviceInfo, resolver:(RCTPromiseResolveBlock)resolve rejecte
     NSString *uniqueId = [DeviceUID uid];
 
     return @{
-             @"DeviceInfo": @{
+             KEY_DEVICE_INFO: @{
                  @"systemName": currentDevice.systemName,
                  @"systemVersion": currentDevice.systemVersion,
                  @"model": self.deviceName,

--- a/RNDeviceInfo/RNDeviceInfo.m
+++ b/RNDeviceInfo/RNDeviceInfo.m
@@ -162,6 +162,23 @@ RCT_EXPORT_MODULE()
   return [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad;
 }
 
+- (bool) is24HourTime
+{
+    NSString *dateFormatter = [NSDateFormatter dateFormatFromTemplate:@"j" options:0 locale:[NSLocale currentLocale]];
+    
+    if (!dateFormatter) {
+        return NO;
+    }
+    
+    NSRange range = [dateFormatter rangeOfString:@"a"];
+    return range.location == NSNotFound;
+}
+
+RCT_REMAP_METHOD(getDeviceInfo, resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+    resolve([self constantsToExport][@"DeviceInfo"]);
+}
+
 - (NSDictionary *)constantsToExport
 {
     UIDevice *currentDevice = [UIDevice currentDevice];
@@ -169,25 +186,27 @@ RCT_EXPORT_MODULE()
     NSString *uniqueId = [DeviceUID uid];
 
     return @{
-             @"systemName": currentDevice.systemName,
-             @"systemVersion": currentDevice.systemVersion,
-             @"model": self.deviceName,
-             @"brand": @"Apple",
-             @"deviceId": self.deviceId,
-             @"deviceName": currentDevice.name,
-             @"deviceLocale": self.deviceLocale,
-             @"deviceCountry": self.deviceCountry ?: [NSNull null],
-             @"uniqueId": uniqueId,
-             @"bundleId": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleIdentifier"],
-             @"appVersion": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"],
-             @"buildNumber": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"],
-             @"systemManufacturer": @"Apple",
-             @"userAgent": self.userAgent,
-             @"timezone": self.timezone,
-             @"isEmulator": @(self.isEmulator),
-             @"isTablet": @(self.isTablet),
-             @"24HourTime" : [[[NSDateFormatter dateFormatFromTemplate:@"j" options:0 locale:[NSLocale currentLocale]] rangeOfString:@"a"] location] == NSNotFound ? @TRUE : @FALSE
-                 };
+             @"DeviceInfo": @{
+                 @"systemName": currentDevice.systemName,
+                 @"systemVersion": currentDevice.systemVersion,
+                 @"model": self.deviceName,
+                 @"brand": @"Apple",
+                 @"deviceId": self.deviceId,
+                 @"deviceName": currentDevice.name ?: [NSNull null],
+                 @"deviceLocale": self.deviceLocale,
+                 @"deviceCountry": self.deviceCountry ?: [NSNull null],
+                 @"uniqueId": uniqueId,
+                 @"bundleId": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleIdentifier"],
+                 @"appVersion": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"],
+                 @"buildNumber": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"],
+                 @"systemManufacturer": @"Apple",
+                 @"userAgent": self.userAgent,
+                 @"timezone": self.timezone,
+                 @"isEmulator": @(self.isEmulator),
+                 @"isTablet": @(self.isTablet),
+                 @"24HourTime" : @([self is24HourTime])
+                 }
+             };
 }
 
 @end

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -69,6 +69,11 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     return layout == Configuration.SCREENLAYOUT_SIZE_LARGE || layout == Configuration.SCREENLAYOUT_SIZE_XLARGE;
   }
 
+  @ReactMethod
+  public void getDeviceInfo(@NonNull final Promise promise) {
+    promise.resolve(this.getConstants().get("DeviceInfo"));
+  }
+
   @Override
   public @Nullable Map<String, Object> getConstants() {
     HashMap<String, Object> constants = new HashMap<String, Object>();
@@ -113,6 +118,9 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     constants.put("timezone", TimeZone.getDefault().getID());
     constants.put("isEmulator", this.isEmulator());
     constants.put("isTablet", this.isTablet());
-    return constants;
+
+    Hashmap<String, Object> constantsWrapper = new HashMap<String, Object>();
+    constantsWrapper.put("DeviceInfo", constants);
+    return constantsWrapper;
   }
 }

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -21,6 +21,8 @@ import javax.annotation.Nullable;
 
 public class RNDeviceModule extends ReactContextBaseJavaModule {
 
+  private static final String KEY_DEVICE_INFO = "DeviceInfo";
+
   ReactApplicationContext reactContext;
 
   public RNDeviceModule(ReactApplicationContext reactContext) {
@@ -71,7 +73,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void getDeviceInfo(@NonNull final Promise promise) {
-    promise.resolve(this.getConstants().get("DeviceInfo"));
+    promise.resolve(this.getConstants().get(KEY_DEVICE_INFO));
   }
 
   @Override
@@ -120,7 +122,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     constants.put("isTablet", this.isTablet());
 
     Hashmap<String, Object> constantsWrapper = new HashMap<String, Object>();
-    constantsWrapper.put("DeviceInfo", constants);
+    constantsWrapper.put(KEY_DEVICE_INFO, constants);
     return constantsWrapper;
   }
 }


### PR DESCRIPTION
This restructures the project to fit our needs:
- Adds a `getDeviceInfo` method, as currently the values are only exported once as constants and are subject to change when the application is in the background.
- Wraps the constants in another hashmap, such that we can access the constants under `RNDeviceInfo.DeviceInfo`, rather than all the constants living on the `RNDeviceInfo` object itself.
- Updates the header search paths of iOS, along with an import statement, to work with our version of ReactNative.

Disclaimer: Not a problem that #6 is still WIP