### PR TITLE
Android compatability fixes

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,5 +20,4 @@ android {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'com.google.android.gms:play-services-gcm:+'
 }

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -85,7 +85,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     String packageName = this.reactContext.getPackageName();
 
     constants.putString("appVersion", "not available");
-    constants.putString("buildVersion", "not availalble");
+    constants.putString("buildVersion", "not available");
     constants.putInt("buildNumber", 0);
 
     try {
@@ -93,7 +93,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
       constants.putString("appVersion", info.versionName);
       constants.putInt("buildNumber", info.versionCode);
     } catch (PackageManager.NameNotFoundException e) {
-      e.printStackTrace();;
+      e.printStackTrace();
     }
 
     String deviceName = "Unknown";

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -6,11 +6,13 @@ import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.os.Build;
 import android.provider.Settings.Secure;
+import android.support.annotation.NonNull;
 
-import com.google.android.gms.iid.InstanceID;
-
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.WritableNativeMap;
 
 import java.util.HashMap;
 import java.util.Locale;
@@ -73,26 +75,25 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void getDeviceInfo(@NonNull final Promise promise) {
-    promise.resolve(this.getConstants().get(KEY_DEVICE_INFO));
+    promise.resolve(this.getWritableConstantsMap());
   }
 
-  @Override
-  public @Nullable Map<String, Object> getConstants() {
-    HashMap<String, Object> constants = new HashMap<String, Object>();
+  public @Nullable WritableNativeMap getWritableConstantsMap() {
+    WritableNativeMap constants = new WritableNativeMap();
 
     PackageManager packageManager = this.reactContext.getPackageManager();
     String packageName = this.reactContext.getPackageName();
 
-    constants.put("appVersion", "not available");
-    constants.put("buildVersion", "not available");
-    constants.put("buildNumber", 0);
+    constants.putString("appVersion", "not available");
+    constants.putString("buildVersion", "not availalble");
+    constants.putInt("buildNumber", 0);
 
     try {
       PackageInfo info = packageManager.getPackageInfo(packageName, 0);
-      constants.put("appVersion", info.versionName);
-      constants.put("buildNumber", info.versionCode);
+      constants.putString("appVersion", info.versionName);
+      constants.putInt("buildNumber", info.versionCode);
     } catch (PackageManager.NameNotFoundException e) {
-      e.printStackTrace();
+      e.printStackTrace();;
     }
 
     String deviceName = "Unknown";
@@ -104,25 +105,28 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
       e.printStackTrace();
     }
 
-    constants.put("instanceId", InstanceID.getInstance(this.reactContext).getId());
-    constants.put("deviceName", deviceName);
-    constants.put("systemName", "Android");
-    constants.put("systemVersion", Build.VERSION.RELEASE);
-    constants.put("model", Build.MODEL);
-    constants.put("brand", Build.BRAND);
-    constants.put("deviceId", Build.BOARD);
-    constants.put("deviceLocale", this.getCurrentLanguage());
-    constants.put("deviceCountry", this.getCurrentCountry());
-    constants.put("uniqueId", Secure.getString(this.reactContext.getContentResolver(), Secure.ANDROID_ID));
-    constants.put("systemManufacturer", Build.MANUFACTURER);
-    constants.put("bundleId", packageName);
-    constants.put("userAgent", System.getProperty("http.agent"));
-    constants.put("timezone", TimeZone.getDefault().getID());
-    constants.put("isEmulator", this.isEmulator());
-    constants.put("isTablet", this.isTablet());
+    constants.putString("deviceName", deviceName);
+    constants.putString("systemName", "Android");
+    constants.putString("systemVersion", Build.VERSION.RELEASE);
+    constants.putString("model", Build.MODEL);
+    constants.putString("brand", Build.BRAND);
+    constants.putString("deviceId", Build.BOARD);
+    constants.putString("deviceLocale", this.getCurrentLanguage());
+    constants.putString("deviceCountry", this.getCurrentCountry());
+    constants.putString("uniqueId", Secure.getString(this.reactContext.getContentResolver(), Secure.ANDROID_ID));
+    constants.putString("systemManufacturer", Build.MANUFACTURER);
+    constants.putString("bundleId", packageName);
+    constants.putString("userAgent", System.getProperty("http.agent"));
+    constants.putString("timezone", TimeZone.getDefault().getID());
+    constants.putBoolean("isEmulator", this.isEmulator());
+    constants.putBoolean("isTablet", this.isTablet());
+    return constants;
+  }
 
-    Hashmap<String, Object> constantsWrapper = new HashMap<String, Object>();
-    constantsWrapper.put(KEY_DEVICE_INFO, constants);
+  @Override
+  public @Nullable Map<String, Object> getConstants() {
+    HashMap<String, Object> constantsWrapper = new HashMap<>();
+    constantsWrapper.put(KEY_DEVICE_INFO, this.getWritableConstantsMap().toHashMap());
     return constantsWrapper;
   }
 }


### PR DESCRIPTION
🔔  **Shame** 🔔 

I had not tested this on android, totally overlooked.

This fixes a number of issues, didn't realize my IDE wasn't showing my any warnings because it couldn't find any project deps. After working within the proper environment, I've cleaned this up to a working state.

### Changes

#### Dependency removal
Removed `com.google.android.gms:play-services-gcm:+` for now. This was conflicting with our primary dependencies causing libraries to become unavailable. **It was only used for `instanceId`**, which we do not need.


#### React error
The `@ReactMethod` was getting a `ReadableMap` when calling `getMap` on the `WritableMap`. This lead to exceptions in React Native as it must be a `WritableMap`, and casting it as such didn't seem to do the trick. 

Now `getWritableConstantsMap` produces a flat map of the values. `getConstants` will use this and embed it inside a `HashMap` containing a root node, with the key `DeviceInfo`. The `@ReactMethod` will simply use the `WritableNativeMap` result from `getWritableConstantsMap` and resolve the `Promise`.