### PR TITLE
Update iOS RN header paths

### DIFF
--- a/RNDeviceInfo.xcodeproj/project.pbxproj
+++ b/RNDeviceInfo.xcodeproj/project.pbxproj
@@ -219,8 +219,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(BUILT_PRODUCTS_DIR)/usr/local/include",
-					"$(SRCROOT)/../../React/**",
-					"$(SRCROOT)/../react-native/React/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "-ObjC";
@@ -235,8 +233,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(BUILT_PRODUCTS_DIR)/usr/local/include",
-					"$(SRCROOT)/../../React/**",
-					"$(SRCROOT)/../react-native/React/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "-ObjC";

--- a/RNDeviceInfo/RNDeviceInfo.h
+++ b/RNDeviceInfo/RNDeviceInfo.h
@@ -9,7 +9,7 @@
 #import <UIKit/UIKit.h>
 #import <sys/utsname.h>
 
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 @interface RNDeviceInfo : NSObject <RCTBridgeModule>
 


### PR DESCRIPTION
Uses the framework import for RN@0.40+