### PR TITLE
Chore - Renaming 24HourTime

### DIFF
--- a/RNDeviceInfo/RNDeviceInfo.m
+++ b/RNDeviceInfo/RNDeviceInfo.m
@@ -206,7 +206,7 @@ RCT_REMAP_METHOD(getDeviceInfo, resolver:(RCTPromiseResolveBlock)resolve rejecte
                  @"timezone": self.timezone,
                  @"isEmulator": @(self.isEmulator),
                  @"isTablet": @(self.isTablet),
-                 @"24HourTime" : @([self is24HourTime])
+                 @"is24HourTime" : @([self is24HourTime])
                  }
              };
 }

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -121,7 +121,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     constants.putString("timezone", TimeZone.getDefault().getID());
     constants.putBoolean("isEmulator", this.isEmulator());
     constants.putBoolean("isTablet", this.isTablet());
-    constants.putBoolean("24HourTime", DateFormat.is24HourFormat(this.reactContext));
+    constants.putBoolean("is24HourTime", DateFormat.is24HourFormat(this.reactContext));
     return constants;
   }
 


### PR DESCRIPTION
Properties that start with numbers are inaccessible to reference with dot notation in Javascript:

```js
DeviceInfo.24HourTime
```
Must be referenced dynamically as
```js
DeviceInfo['24HourTime']
```

This updates the name to `is24HourTime` for safe dot notation access

```js
DeviceInfo.is24HourTime
```