### PR TITLE
Support earlier iOS ReactNative versions

### DIFF
--- a/RNDeviceInfo.xcodeproj/project.pbxproj
+++ b/RNDeviceInfo.xcodeproj/project.pbxproj
@@ -219,6 +219,8 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(BUILT_PRODUCTS_DIR)/usr/local/include",
+					"$(SRCROOT)/../../react-native/React/**",
+					"$(SRCROOT)/../react-native/React/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "-ObjC";
@@ -233,6 +235,8 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(BUILT_PRODUCTS_DIR)/usr/local/include",
+					"$(SRCROOT)/../../react-native/React/**",
+					"$(SRCROOT)/../react-native/React/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "-ObjC";

--- a/RNDeviceInfo/RNDeviceInfo.h
+++ b/RNDeviceInfo/RNDeviceInfo.h
@@ -9,7 +9,11 @@
 #import <UIKit/UIKit.h>
 #import <sys/utsname.h>
 
+#if __has_include(<React/RCTBridgeModule.H>)
 #import <React/RCTBridgeModule.h>
+#else
+#import "RCTBridgeModule.h"
+#endif
 
 @interface RNDeviceInfo : NSObject <RCTBridgeModule>
 

--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -3,63 +3,65 @@
  */
 
 var RNDeviceInfo = require('react-native').NativeModules.RNDeviceInfo;
-
+var DeviceInfo = RNDeviceInfo.DeviceInfo;
 module.exports = {
   getUniqueID: function () {
-    return RNDeviceInfo.uniqueId;
+    return DeviceInfo.uniqueId;
   },
   getInstanceID: function() {
-    return RNDeviceInfo.instanceId;
+    return DeviceInfo.instanceId;
   },
   getDeviceId: function () {
-    return RNDeviceInfo.deviceId;
+    return DeviceInfo.deviceId;
   },
   getManufacturer: function () {
-    return RNDeviceInfo.systemManufacturer;
+    return DeviceInfo.systemManufacturer;
   },
   getModel: function () {
-    return RNDeviceInfo.model;
+    return DeviceInfo.model;
   },
   getBrand: function () {
-    return RNDeviceInfo.brand;
+    return DeviceInfo.brand;
   },
   getSystemName: function () {
-    return RNDeviceInfo.systemName;
+    return DeviceInfo.systemName;
   },
   getSystemVersion: function () {
-    return RNDeviceInfo.systemVersion;
+    return DeviceInfo.systemVersion;
   },
   getBundleId: function() {
-    return RNDeviceInfo.bundleId;
+    return DeviceInfo.bundleId;
   },
   getBuildNumber: function() {
-    return RNDeviceInfo.buildNumber;
+    return DeviceInfo.buildNumber;
   },
   getVersion: function() {
-    return RNDeviceInfo.appVersion;
+    return DeviceInfo.appVersion;
   },
   getReadableVersion: function() {
-    return RNDeviceInfo.appVersion + "." + RNDeviceInfo.buildNumber;
+    return DeviceInfo.appVersion + "." + DeviceInfo.buildNumber;
   },
   getDeviceName: function() {
-    return RNDeviceInfo.deviceName;
+    return DeviceInfo.deviceName;
   },
   getUserAgent: function() {
-    return RNDeviceInfo.userAgent;
+    return DeviceInfo.userAgent;
   },
   getDeviceLocale: function() {
-    return RNDeviceInfo.deviceLocale;
+    return DeviceInfo.deviceLocale;
   },
   getDeviceCountry: function() {
-    return RNDeviceInfo.deviceCountry;
+    return DeviceInfo.deviceCountry;
   },
   getTimezone: function() {
-    return RNDeviceInfo.timezone;
+    return DeviceInfo.timezone;
   },
   isEmulator: function() {
-    return RNDeviceInfo.isEmulator;
+    return DeviceInfo.isEmulator;
   },
   isTablet: function() {
-    return RNDeviceInfo.isTablet;
+    return DeviceInfo.isTablet;
   },
 };
+
+module.exports.DeviceInfo = DeviceInfo;


### PR DESCRIPTION
This adds a backward compatible header import for earlier ReactNative versions that don't support the new framework imports. This is a [common pattern](https://github.com/Microsoft/react-native-code-push/blob/master/ios/CodePush/CodePush.h#L1-L4) for backward compatibility.