### PR TITLE
RN 0.47 compatibility 

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceInfo.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceInfo.java
@@ -23,7 +23,7 @@ public class RNDeviceInfo implements ReactPackage {
     return modules;
   }
 
-  @Override
+  // Deprecated RN 0.47
   public List<Class<? extends JavaScriptModule>> createJSModules() {
   	return Collections.emptyList();
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-device-info",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Get device information using react-native",
   "main": "deviceinfo.js",
   "repository": {


### PR DESCRIPTION
Removes the override for createJSModules to ensure compatibility with React Native 0.47 and above without breaking backwards compatibility.

